### PR TITLE
Fix ESP32-A2DP to version v1.8.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ lib_deps =
 	adafruit/Adafruit NeoPixel@^1.12.3
 	adafruit/Adafruit SSD1306@^2.5.11
 	santerilindfors/WiFiProvisioner@^1.0.0
-	https://github.com/pschatzmann/ESP32-A2DP
+	https://github.com/pschatzmann/ESP32-A2DP#v1.8.5
 	https://github.com/pschatzmann/arduino-audio-tools.git
 	
 board_build.flash_size = 8MB


### PR DESCRIPTION
Needed to fix the version of ESP32-A2DP. Now ordered all parts to get from Breadboard to the real thing :)

Thanks for the instructable.