### PR TITLE
Fixed LEDController.h vs LedController.h typo

### DIFF
--- a/firmware/include/Controllers.h
+++ b/firmware/include/Controllers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "controllers/DisplayController.h"
-#include "controllers/LEDController.h"
+#include "controllers/LedController.h"
 #include "controllers/InputController.h"
 #include "controllers/NetworkController.h"
 #include <Preferences.h>


### PR DESCRIPTION
I was not able to build the firmware on Linux due to this mal typo.