### PR TITLE
Feat/display rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 .DS_Store
+.code-workspace

--- a/firmware/include/Config.h
+++ b/firmware/include/Config.h
@@ -6,6 +6,7 @@
 #define OLED_WIDTH 128
 #define OLED_HEIGHT 64
 #define OLED_ADDR 0x3C
+#define OLED_ROTATION 2  // 0 = 0°, 1 = 90°, 2 = 180°, 3 = 270°
 
 #define LED_PIN 15
 #define NUM_LEDS 16

--- a/firmware/include/Config.h
+++ b/firmware/include/Config.h
@@ -6,15 +6,28 @@
 #define OLED_WIDTH 128
 #define OLED_HEIGHT 64
 #define OLED_ADDR 0x3C
-#define OLED_ROTATION 2  // 0 = 0°, 1 = 90°, 2 = 180°, 3 = 270°
+
+// --- Device Configuration ---
+#define DEVICE_ORIENTATION 0  // 0 = Default, 1 = Rotated 180°
+
+// Configure settings based on orientation
+#if DEVICE_ORIENTATION == 1
+    #define OLED_ROTATION 2  // 180° rotation
+    #define ENCODER_A_PIN 25  // Swapped encoder pins
+    #define ENCODER_B_PIN 27
+    #define ENCODER_REVERSE_VALUE true  // Reverse encoder for timer adjustment
+#else
+    #define OLED_ROTATION 0  // Normal orientation
+    #define ENCODER_A_PIN 27  // Normal encoder pins
+    #define ENCODER_B_PIN 25
+    #define ENCODER_REVERSE_VALUE false  // Normal encoder direction
+#endif
 
 #define LED_PIN 15
 #define NUM_LEDS 16
 #define LED_BRIGHTNESS 100
 
-#define ENCODER_A_PIN 27
-#define ENCODER_B_PIN 25
-#define BUTTON_PIN 26
+#define BUTTON_PIN 26  // A0 on QT Py ESP32
 
 // --- LED Colors ---
 #define BLUE        0x0000FF

--- a/firmware/src/controllers/DisplayController.cpp
+++ b/firmware/src/controllers/DisplayController.cpp
@@ -1,4 +1,5 @@
 #include "controllers/DisplayController.h"
+#include "Config.h"
 
 #include "fonts/Picopixel.h"
 #include "fonts/Org_01.h"
@@ -13,6 +14,9 @@ void DisplayController::begin() {
         for (;;);  // Loop forever if initialization fails
     }
 
+    // Set display rotation from Config.h
+    oled.setRotation(OLED_ROTATION);
+    
     // oled.ssd1306_command(SSD1306_SETCONTRAST);
     // oled.ssd1306_command(128);
     

--- a/firmware/src/controllers/DisplayController.cpp
+++ b/firmware/src/controllers/DisplayController.cpp
@@ -9,20 +9,17 @@ DisplayController::DisplayController(uint8_t oledWidth, uint8_t oledHeight, uint
     : oled(oledWidth, oledHeight, &Wire, -1), animation(&oled) {}
 
 void DisplayController::begin() {
-    if (!oled.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+    Serial.println("Initializing display...");
+    if (!oled.begin(SSD1306_SWITCHCAPVCC, OLED_ADDR)) {
         Serial.println(F("SSD1306 allocation failed"));
         for (;;);  // Loop forever if initialization fails
     }
-
-    // Set display rotation from Config.h
+    Serial.println("Display initialized successfully");
+    Serial.printf("Setting rotation to %d\n", OLED_ROTATION);
     oled.setRotation(OLED_ROTATION);
-    
-    // oled.ssd1306_command(SSD1306_SETCONTRAST);
-    // oled.ssd1306_command(128);
-    
     oled.clearDisplay();
     oled.display();
-    Serial.println("DisplayController initialized.");
+    Serial.println("Display setup complete");
 }
 
 void DisplayController::drawSplashScreen() {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <Wire.h>
 #include "Config.h"
 #include "StateMachine.h"
 #include "Controllers.h"
@@ -12,6 +13,9 @@ Preferences preferences;
 
 void setup() {
     Serial.begin(115200);
+    
+    // Initialize I2C
+    Wire.begin();
     
     // Initialize controllers
     inputController.begin();

--- a/firmware/src/states/AdjustState.cpp
+++ b/firmware/src/states/AdjustState.cpp
@@ -22,8 +22,13 @@ void AdjustState::enter()
         Serial.println("Adjust State: Encoder turned");
         Serial.println(delta);
         
-        // Update duration with delta and enforce bounds
-        this->adjustDuration += (delta * 5);
+        // Update duration based on orientation configuration
+#if ENCODER_REVERSE_VALUE
+        this->adjustDuration -= (delta * 5);  // Reversed
+#else
+        this->adjustDuration += (delta * 5);  // Normal
+#endif
+        
         if (this->adjustDuration < MIN_TIMER) {
             this->adjustDuration = MIN_TIMER;
         } else if (this->adjustDuration > MAX_TIMER) {

--- a/firmware/src/states/ResetState.cpp
+++ b/firmware/src/states/ResetState.cpp
@@ -1,5 +1,6 @@
 #include "StateMachine.h"
 #include "Controllers.h"
+#include "Config.h"
 
 bool resetSelected = false; // button selection
 
@@ -12,11 +13,21 @@ void ResetState::enter()
     // Register state-specific handlers
     inputController.onEncoderRotateHandler([this](int delta)
                                            {
-        if (delta > 0) {
-            resetSelected = true;  // Select "RESET"
-        } else if (delta < 0) {
-            resetSelected = false;  // Select "CANCEL"
-        } });
+        Serial.print("Reset State: Encoder delta = ");
+        Serial.println(delta);
+        
+        // Update selection based on encoder value
+        // Note: When pins are swapped, clockwise = -1, counterclockwise = +1
+        if (delta != 0) {
+#if DEVICE_ORIENTATION == 1
+            resetSelected = (delta > 0);  // When rotated, counterclockwise (+1) selects RESET
+#else
+            resetSelected = (delta < 0);  // When normal, clockwise (-1) selects RESET
+#endif
+            Serial.print("Reset Selected = ");
+            Serial.println(resetSelected);
+        }
+    });
 
     inputController.onPressHandler([this]()
                                    {


### PR DESCRIPTION
Figured out the hard way that if the display is assembled upside down there wasn't a way to rotate the display. This adds a feature to rotate the display and encoder functions  appropriately. 