### PR TITLE
fix: make timer reset non-blocking to prevent watchdog timeout

### DIFF
--- a/firmware/include/states/TimerState.h
+++ b/firmware/include/states/TimerState.h
@@ -11,10 +11,11 @@ public:
     void update() override;
     void exit() override;
 
-    void setTimer(int duration, unsigned long elapsedTime);
+    void setTimer(int duration, unsigned long elapsedTime = 0);
 
 private:
     int duration;
-    unsigned long startTime;
     unsigned long elapsedTime;
+    unsigned long startTime;
+    bool doublePressReceived;  // Flag to handle double press in update loop
 };


### PR DESCRIPTION
I encountered a bug that would cause the dial to reset when I was trying to restart the timer. This was the fix for me. 